### PR TITLE
Add mechanism to allow undefined extensions by default

### DIFF
--- a/dotnet/gen/MetamodelDigest/MetamodelDigest.cs
+++ b/dotnet/gen/MetamodelDigest/MetamodelDigest.cs
@@ -37,6 +37,8 @@
 
             this.PartitionRestrictions = ((JObject)digest["partitions"]).Properties().ToDictionary(p => int.Parse(p.Name), p => new PartitionRestriction((JObject)p.Value));
 
+            this.DtdlVersionsAllowingUndefinedExtensionsByDefault = digest.TryGetValue("dtdlVersionsAllowingUndefinedExtensionsByDefault", out JToken undefinedExtensionToken) ? ((JArray)undefinedExtensionToken).Select(t => ((JValue)t).Value<int>()).ToList() : new List<int>();
+
             this.DtdlVersionsAllowingLocalTerms = ((JArray)digest["dtdlVersionsAllowingLocalTerms"]).Select(t => ((JValue)t).Value<int>()).ToList();
 
             this.DtdlVersionsAllowingDynamicExtensions = ((JArray)digest["dtdlVersionsAllowingDynamicExtensions"]).Select(t => ((JValue)t).Value<int>()).ToList();
@@ -125,6 +127,12 @@
         /// Gets a dictionary that maps from DTDL version to a <see cref="PartitionRestriction"/> object that describes restrictions on partition classes.
         /// </summary>
         public Dictionary<int, PartitionRestriction> PartitionRestrictions { get; }
+
+        /// <summary>
+        /// Gets a list of DTDL versions that by default allow undefined extension contexts to be specified in models.
+        /// This behavior can be overridden for all DTDL versions by the <c>AllowUndefinedExtensions</c> field in <c>ParsingOptions</c>.
+        /// </summary>
+        public List<int> DtdlVersionsAllowingUndefinedExtensionsByDefault { get; }
 
         /// <summary>
         /// Gets a list of DTDL versions that allow local term definitions in context blocks.

--- a/dotnet/gen/ParserGenerator/ContextCollectionGenerator.cs
+++ b/dotnet/gen/ParserGenerator/ContextCollectionGenerator.cs
@@ -8,6 +8,7 @@
     public class ContextCollectionGenerator : ITypeGenerator
     {
         private readonly Dictionary<string, Dictionary<string, string>> contexts;
+        private readonly List<int> dtdlVersionsAllowingUndefinedExtensionsByDefault;
         private readonly List<int> dtdlVersionsAllowingLocalTerms;
         private readonly List<int> dtdlVersionsRestrictingKeywords;
         private readonly List<int> dtdlVersionsAllowingDynamicExtensions;
@@ -22,6 +23,7 @@
         /// </summary>
         /// <param name="contexts">A dictionary that maps from a context ID to a dictionary of term definitions.</param>
         /// <param name="supplementalTypes">A dictionary that maps from type URI to a <see cref="SupplementalTypeDigest"/> object providing details about the identified supplemental type.</param>
+        /// <param name="dtdlVersionsAllowingUndefinedExtensionsByDefault">A list of DTDL versions that by default allow undefined extension contexts to be specified in models.</param>
         /// <param name="dtdlVersionsAllowingLocalTerms">A list of DTDL versions that allow local term definitions in context blocks.</param>
         /// <param name="dtdlVersionsAllowingDynamicExtensions">A list of DTDL versions that allow language extensions to be added dynamically.</param>
         /// <param name="dtdlVersionsRestrictingKeywords">A list of DTDL versions that restrict the use of JSON-LD keywords.</param>
@@ -32,6 +34,7 @@
         public ContextCollectionGenerator(
             Dictionary<string, Dictionary<string, string>> contexts,
             Dictionary<string, SupplementalTypeDigest> supplementalTypes,
+            List<int> dtdlVersionsAllowingUndefinedExtensionsByDefault,
             List<int> dtdlVersionsAllowingLocalTerms,
             List<int> dtdlVersionsAllowingDynamicExtensions,
             List<int> dtdlVersionsRestrictingKeywords,
@@ -41,6 +44,7 @@
             bool areDynamicExtensionsSupported)
         {
             this.contexts = contexts;
+            this.dtdlVersionsAllowingUndefinedExtensionsByDefault = dtdlVersionsAllowingUndefinedExtensionsByDefault;
             this.dtdlVersionsAllowingLocalTerms = dtdlVersionsAllowingLocalTerms;
             this.dtdlVersionsAllowingDynamicExtensions = dtdlVersionsAllowingDynamicExtensions;
             this.dtdlVersionsRestrictingKeywords = dtdlVersionsRestrictingKeywords;
@@ -91,6 +95,9 @@
         private void GenerateStaticConstructor(CsClass contextClass)
         {
             CsConstructor constructor = contextClass.Constructor(Access.Implicit, Multiplicity.Static);
+
+            constructor.Body.Line($"DtdlVersionsAllowingUndefinedExtensionsByDefault = new HashSet<int>() {{ {string.Join(", ", this.dtdlVersionsAllowingUndefinedExtensionsByDefault)} }};");
+            constructor.Body.Break();
 
             constructor.Body.Line($"DtdlVersionsAllowingLocalTerms = new HashSet<int>() {{ {string.Join(", ", this.dtdlVersionsAllowingLocalTerms)} }};");
             constructor.Body.Break();

--- a/dotnet/gen/ParserGenerator/ModelParserGenerator.cs
+++ b/dotnet/gen/ParserGenerator/ModelParserGenerator.cs
@@ -100,7 +100,7 @@
                 .Line("this.dtmiResolverAsync = null;")
                 .Line("this.dtdlResolveLocator = null;")
                 .Line("this.MaxDtdlVersion = ParsingOptions.MaxKnownDtdlVersion;")
-                .Line("this.AllowUndefinedExtensions = false;");
+                .Line("this.AllowUndefinedExtensions = WhenToAllow.PerDefault;");
 
             if (this.isLayeringSupported)
             {

--- a/dotnet/gen/ParserGenerator/ParsingOptionsGenerator.cs
+++ b/dotnet/gen/ParserGenerator/ParsingOptionsGenerator.cs
@@ -9,34 +9,50 @@
     public class ParsingOptionsGenerator : ITypeGenerator
     {
         private readonly bool isLayeringSupported;
-        private readonly int minKnownDtdlVersion;
-        private readonly int maxKnownDtdlVersion;
+        private readonly List<int> dtdlVersions;
+        private readonly List<int> dtdlVersionsAllowingUndefinedExtensionsByDefault;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParsingOptionsGenerator"/> class.
         /// </summary>
         /// <param name="isLayeringSupported">True if multiple model layers are supported by any recognized language version or extension.</param>
         /// <param name="dtdlVersions">A list of DTDL (major) version numbers defined in the metamodel digest.</param>
-        public ParsingOptionsGenerator(bool isLayeringSupported, List<int> dtdlVersions)
+        /// <param name="dtdlVersionsAllowingUndefinedExtensionsByDefault">A list of DTDL versions that by default allow undefined extension contexts to be specified in models.</param>
+        public ParsingOptionsGenerator(bool isLayeringSupported, List<int> dtdlVersions, List<int> dtdlVersionsAllowingUndefinedExtensionsByDefault)
         {
             this.isLayeringSupported = isLayeringSupported;
-            this.minKnownDtdlVersion = dtdlVersions.Min();
-            this.maxKnownDtdlVersion = dtdlVersions.Max();
+            this.dtdlVersions = dtdlVersions;
+            this.dtdlVersionsAllowingUndefinedExtensionsByDefault = dtdlVersionsAllowingUndefinedExtensionsByDefault;
         }
 
         /// <inheritdoc/>
         public void GenerateCode(CsLibrary parserLibrary)
         {
+            int minKnownDtdlVersion = this.dtdlVersions.Min();
+            int maxKnownDtdlVersion = this.dtdlVersions.Max();
+
             CsClass optionsClass = parserLibrary.Class(Access.Public, Novelty.Normal, "ParsingOptions", completeness: Completeness.Partial);
             optionsClass.Summary("Class <c>ParsingOptions</c> defines properties that can be passed into the <see cref=\"ModelParser\"/> constructor to configure its behavior.");
 
-            optionsClass.Constant(Access.Public, "int", "MinKnownDtdlVersion", this.minKnownDtdlVersion.ToString(), "The lowest version of DTDL understood by this version of <see cref=\"ModelParser\"/>.");
-            optionsClass.Constant(Access.Public, "int", "MaxKnownDtdlVersion", this.maxKnownDtdlVersion.ToString(), "The highest version of DTDL understood by this version of <see cref=\"ModelParser\"/>.");
+            optionsClass.Constant(Access.Public, "int", "MinKnownDtdlVersion", minKnownDtdlVersion.ToString(), "The lowest version of DTDL understood by this version of <see cref=\"ModelParser\"/>.");
+            optionsClass.Constant(Access.Public, "int", "MaxKnownDtdlVersion", maxKnownDtdlVersion.ToString(), "The highest version of DTDL understood by this version of <see cref=\"ModelParser\"/>.");
 
             CsProperty maxDtdlVersionProperty = optionsClass.Property(Access.Public, Novelty.Normal, "int", "MaxDtdlVersion");
             maxDtdlVersionProperty.Summary("Gets or sets an integer value that restricts the highest DTDL version the parser should accept; if a higher version model is submitted, a <see cref=\"ParsingException\"/> will be thrown with a <see cref=\"ParsingError\"/> indicating a <c>ValidationID</c> of dtmi:dtdl:parsingError:disallowedContextVersion.");
-            maxDtdlVersionProperty.Remarks($"The default value is {this.maxKnownDtdlVersion}, because this is the highest version of DTDL understood by this version of <see cref=\"ModelParser\"/>.");
+            maxDtdlVersionProperty.Remarks($"The default value is {maxKnownDtdlVersion}, because this is the highest version of DTDL understood by this version of <see cref=\"ModelParser\"/>.");
             maxDtdlVersionProperty.Get().Set().Default("MaxKnownDtdlVersion");
+
+            CsProperty allowUndefinedExtensionsProperty = optionsClass.Property(Access.Public, Novelty.Normal, "WhenToAllow", "AllowUndefinedExtensions");
+            allowUndefinedExtensionsProperty.Summary("Gets or sets a value indicating whether and when the parser should continue parsing if it encounters a reference to an extension that cannot be resolved.");
+            allowUndefinedExtensionsProperty.Summary("If this property is <see cref=\"WhenToAllow.Never\"/>, an undefined extension context in a model will result in a <see cref=\"ParsingException\"/> with a <see cref=\"ParsingError\"/> indicating a <c>ValidationID</c> of dtmi:dtdl:parsingError:unresolvableContextSpecifier or dtmi:dtdl:parsingError:unresolvableContextVersion.");
+            allowUndefinedExtensionsProperty.Summary("If this property is <see cref=\"WhenToAllow.Always\"/>, an undefined extension context in a model will not interrupt parsing, and furthermore the presence of this undefined context will allow the model to use undefined co-types and to use undefined properties in elements that have undefined co-types.");
+            allowUndefinedExtensionsProperty.Summary("If this property is not set or is set to <see cref=\"WhenToAllow.PerDefault\"/>, the parsing behavior is determined according to the version of the DTDL context specified by the model.");
+            allowUndefinedExtensionsProperty.Get().Set().Default("WhenToAllow.PerDefault");
+            foreach (int dtdlVersion in this.dtdlVersions)
+            {
+                string defaultBehavior = this.dtdlVersionsAllowingUndefinedExtensionsByDefault.Contains(dtdlVersion) ? "allow" : "disallow";
+                allowUndefinedExtensionsProperty.Remarks($"For DTDL v{dtdlVersion}, the default behavior is to {defaultBehavior} undefined extensions.");
+            }
 
             if (this.isLayeringSupported)
             {

--- a/dotnet/gen/ParserGenerator/Program.cs
+++ b/dotnet/gen/ParserGenerator/Program.cs
@@ -59,7 +59,7 @@
 
                 List<ITypeGenerator> typeGenerators = new List<ITypeGenerator>();
 
-                typeGenerators.Add(new ContextCollectionGenerator(metamodelDigest.Contexts, metamodelDigest.SupplementalTypes, metamodelDigest.DtdlVersionsAllowingLocalTerms, metamodelDigest.DtdlVersionsAllowingDynamicExtensions, metamodelDigest.DtdlVersionsRestrictingKeywords, metamodelDigest.ContextsMergeDefinitions, metamodelDigest.ReservedIdPrefixes, metamodelDigest.AffiliateContextsImplicitDtdlVersions, areDynamicExtensionsSupported));
+                typeGenerators.Add(new ContextCollectionGenerator(metamodelDigest.Contexts, metamodelDigest.SupplementalTypes, metamodelDigest.DtdlVersionsAllowingUndefinedExtensionsByDefault, metamodelDigest.DtdlVersionsAllowingLocalTerms, metamodelDigest.DtdlVersionsAllowingDynamicExtensions, metamodelDigest.DtdlVersionsRestrictingKeywords, metamodelDigest.ContextsMergeDefinitions, metamodelDigest.ReservedIdPrefixes, metamodelDigest.AffiliateContextsImplicitDtdlVersions, areDynamicExtensionsSupported));
                 typeGenerators.Add(new AggregateContextGenerator(metamodelDigest.BaseClass, areDynamicExtensionsSupported, metamodelDigest.SupplementalTypes));
                 typeGenerators.Add(new HelpersGenerator(metamodelDigest.BaseClass));
                 typeGenerators.Add(new StandardElementCollectionGenerator(metamodelDigest.BaseClass, metamodelDigest.Aliases));
@@ -69,7 +69,7 @@
                 typeGenerators.Add(new RootableGenerator(metamodelDigest.IsLayeringSupported));
                 typeGenerators.Add(new ModelGenerator(metamodelDigest.BaseClass, metamodelDigest.ReservedIdPrefixes));
                 typeGenerators.Add(new ModelParserGenerator(metamodelDigest.BaseClass, areDynamicExtensionsSupported, metamodelDigest.IsLayeringSupported, outTsFile));
-                typeGenerators.Add(new ParsingOptionsGenerator(metamodelDigest.IsLayeringSupported, metamodelDigest.DtdlVersions));
+                typeGenerators.Add(new ParsingOptionsGenerator(metamodelDigest.IsLayeringSupported, metamodelDigest.DtdlVersions, metamodelDigest.DtdlVersionsAllowingUndefinedExtensionsByDefault));
                 typeGenerators.Add(new SupplementalTypeInfoGenerator(metamodelDigest.BaseClass, metamodelDigest.ExtensionKinds, metamodelDigest.MaterialClasses));
                 typeGenerators.Add(new PartitionTypeCollectionGenerator(metamodelDigest.PartitionClasses, metamodelDigest.Contexts, metamodelDigest.PartitionRestrictions, metamodelDigest.DtdlVersions));
                 typeGenerators.Add(new RootableTypeCollectionGenerator(metamodelDigest.RootableClasses, metamodelDigest.Contexts));

--- a/dotnet/gen/RemodelGenerator/RemodelerGenerator.cs
+++ b/dotnet/gen/RemodelGenerator/RemodelerGenerator.cs
@@ -231,7 +231,7 @@
             method.Param("bool", "allowUndefinedExtensions", null, "false");
             method.Param("int", "maxDtdlVersion", null, "0");
 
-            method.Body.Line("var parsingOptions = new ParsingOptions() { AllowUndefinedExtensions = allowUndefinedExtensions };");
+            method.Body.Line("var parsingOptions = new ParsingOptions() { AllowUndefinedExtensions = allowUndefinedExtensions ? WhenToAllow.Always : WhenToAllow.Never };");
 
             method.Body.If("maxDtdlVersion > 0")
                 .Line("parsingOptions.MaxDtdlVersion = maxDtdlVersion;");

--- a/dotnet/gen/UnitTestGenerator/ParserUnitTesterGenerator.cs
+++ b/dotnet/gen/UnitTestGenerator/ParserUnitTesterGenerator.cs
@@ -51,6 +51,15 @@
                 .Break();
 
             executeTestCaseMethod.Body
+                .Line("bool disallowUndefinedExtensions = optionsToken.Any(t => ((JValue)t).Value<string>() == \"DisallowUndefinedExtensions\");")
+                .Line("remainingOptionCount -= disallowUndefinedExtensions ? 1 : 0;")
+                .Break();
+
+            executeTestCaseMethod.Body
+                .Line("WhenToAllow allowUndefinedExtensionsInTest = allowUndefinedExtensions ? WhenToAllow.Always : disallowUndefinedExtensions ? WhenToAllow.Never : WhenToAllow.PerDefault;")
+                .Break();
+
+            executeTestCaseMethod.Body
                 .If("remainingOptionCount > 0")
                     .Line("Assert.Inconclusive(\"Unrecognized ModelParsingOption\");");
 
@@ -86,7 +95,7 @@
         {
             CsMethod getModelParserMethod = parserUnitTesterClass.Method(Access.Private, Novelty.Normal, "ModelParser", "GetModelParser", Multiplicity.Static);
             getModelParserMethod.Param("int?", "maxDtdlVersion");
-            getModelParserMethod.Param("bool", "allowUndefinedExtensions");
+            getModelParserMethod.Param("WhenToAllow", "allowUndefinedExtensions");
             getModelParserMethod.Param("ModelParsingQuirk", "quirks");
             getModelParserMethod.Param("JObject", "testCaseObject");
             getModelParserMethod.Param("bool", "useAsyncApi");
@@ -221,7 +230,7 @@
 
         private CsScope GetModelParser(CsScope outerScope)
         {
-            const string callGetModelParser = "ModelParser modelParser = GetModelParser(maxDtdlVersion, allowUndefinedExtensions, quirks, testCaseObject, useAsyncApi, maxReadConcurrency, out IResolutionChecker resolutionChecker, out IResolutionChecker partialResolutionChecker)";
+            const string callGetModelParser = "ModelParser modelParser = GetModelParser(maxDtdlVersion, allowUndefinedExtensionsInTest, quirks, testCaseObject, useAsyncApi, maxReadConcurrency, out IResolutionChecker resolutionChecker, out IResolutionChecker partialResolutionChecker)";
 
             if (this.areDynamicExtensionsSupported)
             {

--- a/dotnet/src/DTDLParser/ContextCollection.cs
+++ b/dotnet/src/DTDLParser/ContextCollection.cs
@@ -17,6 +17,7 @@ namespace DTDLParser
         private static readonly ContextHistory DtdlContextHistory;
         private static readonly Dictionary<string, ContextHistory> EndogenousAffiliateContextHistories;
 
+        private static readonly HashSet<int> DtdlVersionsAllowingUndefinedExtensionsByDefault;
         private static readonly HashSet<int> DtdlVersionsAllowingLocalTerms;
         private static readonly HashSet<int> DtdlVersionsRestrictingKeywords;
         private static readonly Dictionary<string, int> EndogenousAffiliateContextsImplicitDtdlVersions;
@@ -116,6 +117,16 @@ namespace DTDLParser
             {
                 this.exogenousAffiliateContextHistories[affiliateName] = new ContextHistory(new List<VersionedContext>() { versionedContext });
             }
+        }
+
+        /// <summary>
+        /// Indicates whether a given DTDL version by default allows undefined extension contexts to be specified in models.
+        /// </summary>
+        /// <param name="dtdlVersion">The DTDL version number to check.</param>
+        /// <returns>True if undefined extension contexts are permitted.</returns>
+        internal bool DoesDtdlVersionAllowUndefinedExtensionsByDefault(int dtdlVersion)
+        {
+            return DtdlVersionsAllowingUndefinedExtensionsByDefault.Contains(dtdlVersion);
         }
 
         /// <summary>

--- a/dotnet/src/DTDLParser/ModelParser.cs
+++ b/dotnet/src/DTDLParser/ModelParser.cs
@@ -33,10 +33,12 @@ namespace DTDLParser
         public int MaxDtdlVersion { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the parser will continue parsing if it encounters a reference to an extension that cannot be resolved.
-        /// When this property is true, the parser will not throw a <see cref="ParsingException"/> with a <see cref="ParsingError"/> indicating a <c>ValidationID</c> of dtmi:dtdl:parsingError:unresolvableContextSpecifier or dtmi:dtdl:parsingError:unresolvableContextVersion.
+        /// Gets a value indicating whether and when the parser will continue parsing if it encounters a reference to an extension that cannot be resolved.
+        /// If this property is <see cref="WhenToAllow.Never"/>, an undefined extension context in a model will result in a <see cref="ParsingException"/> with a <see cref="ParsingError"/> indicating a <c>ValidationID</c> of dtmi:dtdl:parsingError:unresolvableContextSpecifier or dtmi:dtdl:parsingError:unresolvableContextVersion.
+        /// If this property is <see cref="WhenToAllow.Always"/>, an undefined extension context in a model will not interrupt parsing, and furthermore the presence of this undefined context will allow the model to use undefined co-types and to use undefined properties in elements that have undefined co-types.
+        /// If this property is not set or is set to <see cref="WhenToAllow.PerDefault"/>, the parsing behavior is determined according to the version of the DTDL context specified by the model.
         /// </summary>
-        public bool AllowUndefinedExtensions { get; }
+        public WhenToAllow AllowUndefinedExtensions { get; }
 
         /// <summary>
         /// Get a term from a URI if defined in the context. If not, return the URI as a string.

--- a/dotnet/src/DTDLParser/ParsingOptions.cs
+++ b/dotnet/src/DTDLParser/ParsingOptions.cs
@@ -22,11 +22,5 @@ namespace DTDLParser
         /// Gets or sets an optional <c>DtdlResolveLocator</c> delegate that will be called to convert a resolve DTMI and line number into a source name and line number.
         /// </summary>
         public DtdlResolveLocator DtdlResolveLocator { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the parser should continue parsing if it encounters a reference to an extension that cannot be resolved.
-        /// If this property is true, the parser will not throw a <see cref="ParsingException"/> with a <see cref="ParsingError"/> indicating a <c>ValidationID</c> of dtmi:dtdl:parsingError:unresolvableContextSpecifier or dtmi:dtdl:parsingError:unresolvableContextVersion.
-        /// </summary>
-        public bool AllowUndefinedExtensions { get; set; } = false;
     }
 }

--- a/dotnet/src/DTDLParser/StandardElementCollection.cs
+++ b/dotnet/src/DTDLParser/StandardElementCollection.cs
@@ -23,7 +23,7 @@ namespace DTDLParser
             EndogenousElementReferences = new Dictionary<Dtmi, HashSet<Dtmi>>();
 
             var objectPropertyInfoList = new List<ParsedObjectPropertyInfo>();
-            var endogenousAggregateContext = new AggregateContext(new ContextCollection(), new SupplementalTypeCollection(), allowUndefinedExtensions: false, suppressDefinitionMerging: true);
+            var endogenousAggregateContext = new AggregateContext(new ContextCollection(), new SupplementalTypeCollection(), allowUndefinedExtensions: WhenToAllow.Never, suppressDefinitionMerging: true);
             var parsingErrorCollection = new ParsingErrorCollection();
 
             ParseResourceIntoEndogenousStandardModel(Assembly.GetExecutingAssembly().GetManifestResourceNames().First(), objectPropertyInfoList, endogenousAggregateContext, parsingErrorCollection);

--- a/dotnet/src/DTDLParser/WhenToAllow.cs
+++ b/dotnet/src/DTDLParser/WhenToAllow.cs
@@ -1,0 +1,26 @@
+namespace DTDLParser
+{
+    using System;
+
+    /// <summary>
+    /// Enum <c>WhenToAllow</c> is a value type for a property that indicates when a particular syntax, function, behavior, or feature indicated by the property is allowed to be used in a DTDL model.
+    /// </summary>
+    public enum WhenToAllow
+    {
+        /// <summary>
+        /// The syntax, function, behavior, or feature is allowed or disallowed per the default specified by the metamodel for the DTDL language version.
+        /// The defaults may be different for different language versions.
+        /// </summary>
+        PerDefault = 0,
+
+        /// <summary>
+        /// The syntax, function, behavior, or feature is always allowed for every model written in any DTDL language version.
+        /// </summary>
+        Always = 1,
+
+        /// <summary>
+        /// The syntax, function, behavior, or feature is never allowed for any model written in any DTDL language version.
+        /// </summary>
+        Never = 2,
+    }
+}

--- a/dotnet/src/DTDLParser/generated/ContextCollection.g.cs
+++ b/dotnet/src/DTDLParser/generated/ContextCollection.g.cs
@@ -22,6 +22,8 @@ namespace DTDLParser
     {
         static ContextCollection()
         {
+            DtdlVersionsAllowingUndefinedExtensionsByDefault = new HashSet<int>() {  };
+
             DtdlVersionsAllowingLocalTerms = new HashSet<int>() {  };
 
             DtdlVersionsRestrictingKeywords = new HashSet<int>() { 3 };

--- a/dotnet/src/DTDLParser/generated/ModelParser.g.cs
+++ b/dotnet/src/DTDLParser/generated/ModelParser.g.cs
@@ -49,7 +49,7 @@ namespace DTDLParser
                 this.dtmiResolverAsync = null;
                 this.dtdlResolveLocator = null;
                 this.MaxDtdlVersion = ParsingOptions.MaxKnownDtdlVersion;
-                this.AllowUndefinedExtensions = false;
+                this.AllowUndefinedExtensions = WhenToAllow.PerDefault;
             }
 
             this.jsonLdResolvingReader = new JsonLdReader(this.dtdlResolveLocator);

--- a/dotnet/src/DTDLParser/generated/ParsingOptions.g.cs
+++ b/dotnet/src/DTDLParser/generated/ParsingOptions.g.cs
@@ -37,5 +37,17 @@ namespace DTDLParser
         /// The default value is 3, because this is the highest version of DTDL understood by this version of <see cref="ModelParser"/>.
         /// </remarks>
         public int MaxDtdlVersion { get; set; } = MaxKnownDtdlVersion;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether and when the parser should continue parsing if it encounters a reference to an extension that cannot be resolved.
+        /// If this property is <see cref="WhenToAllow.Never"/>, an undefined extension context in a model will result in a <see cref="ParsingException"/> with a <see cref="ParsingError"/> indicating a <c>ValidationID</c> of dtmi:dtdl:parsingError:unresolvableContextSpecifier or dtmi:dtdl:parsingError:unresolvableContextVersion.
+        /// If this property is <see cref="WhenToAllow.Always"/>, an undefined extension context in a model will not interrupt parsing, and furthermore the presence of this undefined context will allow the model to use undefined co-types and to use undefined properties in elements that have undefined co-types.
+        /// If this property is not set or is set to <see cref="WhenToAllow.PerDefault"/>, the parsing behavior is determined according to the version of the DTDL context specified by the model.
+        /// </summary>
+        /// <remarks>
+        /// For DTDL v2, the default behavior is to disallow undefined extensions.
+        /// For DTDL v3, the default behavior is to disallow undefined extensions.
+        /// </remarks>
+        public WhenToAllow AllowUndefinedExtensions { get; set; } = WhenToAllow.PerDefault;
     }
 }

--- a/dotnet/src/Remodel/generated/Remodeler.g.cs
+++ b/dotnet/src/Remodel/generated/Remodeler.g.cs
@@ -170,7 +170,7 @@ namespace DTDLParser
 
         private bool TryValidateModel(out IReadOnlyDictionary<Dtmi, DTEntityInfo> model, out IList<ParsingError> parsingErrors, out IList<Dtmi> undefinedIdentifiers, bool allowUndefinedExtensions = false, int maxDtdlVersion = 0)
         {
-            var parsingOptions = new ParsingOptions() { AllowUndefinedExtensions = allowUndefinedExtensions };
+            var parsingOptions = new ParsingOptions() { AllowUndefinedExtensions = allowUndefinedExtensions ? WhenToAllow.Always : WhenToAllow.Never };
             if (maxDtdlVersion > 0)
             {
                 parsingOptions.MaxDtdlVersion = maxDtdlVersion;

--- a/dotnet/tests/ParserUnitTest/generated/ParserUnitTester.g.cs
+++ b/dotnet/tests/ParserUnitTest/generated/ParserUnitTester.g.cs
@@ -15,7 +15,7 @@ namespace ParserUnitTest
 
     internal static partial class ParserUnitTester
     {
-        private static ModelParser GetModelParser(int? maxDtdlVersion, bool allowUndefinedExtensions, ModelParsingQuirk quirks, JObject testCaseObject, bool useAsyncApi, int maxReadConcurrency, out IResolutionChecker resolutionChecker, out IResolutionChecker partialResolutionChecker)
+        private static ModelParser GetModelParser(int? maxDtdlVersion, WhenToAllow allowUndefinedExtensions, ModelParsingQuirk quirks, JObject testCaseObject, bool useAsyncApi, int maxReadConcurrency, out IResolutionChecker resolutionChecker, out IResolutionChecker partialResolutionChecker)
         {
             TestDtmiResolver dtmiResolver = new TestDtmiResolver(testCaseObject, useAsyncApi);
             resolutionChecker = dtmiResolver;
@@ -44,6 +44,11 @@ namespace ParserUnitTest
             bool allowUndefinedExtensions = optionsToken.Any(t => ((JValue)t).Value<string>() == "AllowUndefinedExtensions");
             remainingOptionCount -= allowUndefinedExtensions ? 1 : 0;
 
+            bool disallowUndefinedExtensions = optionsToken.Any(t => ((JValue)t).Value<string>() == "DisallowUndefinedExtensions");
+            remainingOptionCount -= disallowUndefinedExtensions ? 1 : 0;
+
+            WhenToAllow allowUndefinedExtensionsInTest = allowUndefinedExtensions ? WhenToAllow.Always : disallowUndefinedExtensions ? WhenToAllow.Never : WhenToAllow.PerDefault;
+
             if (remainingOptionCount > 0)
             {
                 Assert.Inconclusive("Unrecognized ModelParsingOption");
@@ -63,7 +68,7 @@ namespace ParserUnitTest
 
             bool inputGiven = testCaseObject.TryGetValue("input", out JToken inputToken);
 
-            ModelParser modelParser = GetModelParser(maxDtdlVersion, allowUndefinedExtensions, quirks, testCaseObject, useAsyncApi, maxReadConcurrency, out IResolutionChecker resolutionChecker, out IResolutionChecker partialResolutionChecker);
+            ModelParser modelParser = GetModelParser(maxDtdlVersion, allowUndefinedExtensionsInTest, quirks, testCaseObject, useAsyncApi, maxReadConcurrency, out IResolutionChecker resolutionChecker, out IResolutionChecker partialResolutionChecker);
             if (testCaseObject.TryGetValue("extensions", out JToken loadToken))
             {
                 TestExtension(modelParser, loadToken, testCaseObject, extensionValid: valid || inputGiven);

--- a/test-cases/solecisms/InterfaceContentsDuplicateNameAutogenIdOnParseWithParseToleratingV2.json
+++ b/test-cases/solecisms/InterfaceContentsDuplicateNameAutogenIdOnParseWithParseToleratingV2.json
@@ -1,7 +1,7 @@
 ﻿{
   "valid": true,
   "quirks": [
-    "InterfaceContentsDuplicateNameAutogenIdOnParseWithParseToleratingV2.json"
+    "TolerateSolecismsInParse"
   ],
   "options": [],
   "input": [

--- a/tutorials/Tutorial16_ValidateAndInspectAContextuallyIncompleteModel.md
+++ b/tutorials/Tutorial16_ValidateAndInspectAContextuallyIncompleteModel.md
@@ -98,10 +98,10 @@ Alternatively, this context may refer to an expected future language extension t
 In either case, a service or tool may benefit from being able to perform a best-effort validation of the understood portions of the model and to inspect the opaque portions.
 
 The `ModelParser` constructor takes an optional parameter of type `ParsingOptions` that controls the parsing of DTDL models.
-The following snippet instantiates a new parser with a `ParsingOptions` instance whose `AllowUndefinedExtensions` property is `true`.
+The following snippet instantiates a new parser with a `ParsingOptions` instance whose `AllowUndefinedExtensions` property is `WhenToAllow.Always`.
 
 ```C# Snippet:DtdlParserTutorial16_NewParserSetAllowUndefinedExtensions
-modelParser = new ModelParser(new ParsingOptions() { AllowUndefinedExtensions = true });
+modelParser = new ModelParser(new ParsingOptions() { AllowUndefinedExtensions = WhenToAllow.Always });
 ```
 
 [repeat]: # (Snippet:DtdlParserTutorial16_CallParse)

--- a/tutorials/projects/Tutorial16/Program.g.cs
+++ b/tutorials/projects/Tutorial16/Program.g.cs
@@ -72,7 +72,7 @@ namespace Tutorial16
             #endregion
 
             #region Snippet:DtdlParserTutorial16_NewParserSetAllowUndefinedExtensions
-            modelParser = new ModelParser(new ParsingOptions() { AllowUndefinedExtensions = true });
+            modelParser = new ModelParser(new ParsingOptions() { AllowUndefinedExtensions = WhenToAllow.Always });
             #endregion
 
             try


### PR DESCRIPTION
This is just the parser mechanism.  A DTDL metamodel/metaparser change is needed to set the default to allow undefined extensions in DTDL v2.